### PR TITLE
Upgraded Levenshtein implementation

### DIFF
--- a/levenshtein.lisp
+++ b/levenshtein.lisp
@@ -1,20 +1,43 @@
 (in-package #:vas-string-metrics)
 
-(defun levenshtein-distance (s1 s2)
+(defun levenshtein-distance (s1 s2
+                             &key (key #'identity))
   "Finds the Levenshtein distance (minimum number of edits) from string s1 to string s2."
-  (let ((previous-row (make-array (list (1+ (length s1)))))
-        (current-row (make-array (list (1+ (length s1))))))
-    (dotimes (i (length previous-row))
-      (setf (aref previous-row i) i))
-    (loop for r from 1 below (1+ (length s2)) do
-         (loop for c from 1 below (1+ (length s1)) do
-              (setf (aref current-row 0) r
-                    (aref current-row c) (min (1+ (aref previous-row c))
-                                              (1+ (aref current-row (1- c)))
-                                              (+ (if (equalp (aref s1 (1- c)) (aref s2 (1- r))) 0 1)
-                                                 (aref previous-row (1- c))))))
-         (rotatef previous-row current-row))
-    (aref previous-row (1- (length previous-row)))))
+  (let* ((s1len (length s1))
+         (s2len (length s2))
+         (buf (make-array s1len
+                          :element-type 'integer
+                          :initial-element 0))
+         (prev 0))
+    (loop
+       for i below s1len
+       do (setf (aref buf i) (1+ i)))
+    (loop
+       for row below s2len
+       do
+         (let* ((col 0)
+                (dist
+                 (if (char= (funcall key (aref s1 col))
+                            (funcall key (aref s2 row)))
+                     row
+                     (1+ (min row
+                              (aref buf col))))))
+           (setf prev dist))
+         (loop
+            for col from 1 below s1len
+            do
+              (let* ((dist
+                      (if (char= (funcall key (aref s1 col))
+                                 (funcall key (aref s2 row)))
+                          (aref buf (1- col))
+                          (1+ (min prev
+                                   (aref buf (1- col))
+                                   (aref buf col))))))
+                (setf (aref buf (1- col))
+                      prev)
+                (setf prev dist)))
+         (setf (aref buf (1- s1len)) prev))
+    prev))
 
 (defun normalized-levenshtein-distance (s1 s2)
   "Finds the normalized Levenshtein distance (from 0 for no similarity


### PR DESCRIPTION
I changed the Levenshtein metric function to

1. Be case-sensitive
2. Support a :key argument so that e.g. case-insensitive uses can still work (e.g. :key #'char-upcase)
3. Use the single-row memory optimization